### PR TITLE
Fixed rubocop and foodcritic for osl-drupal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ Berksfile.lock
 \#*#
 .*.sw[a-z]
 *.un~
-/cookbooks
 
 # Bundler
 Gemfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,3 +3,7 @@ suites:
   - name: default
     run_list:
       - recipe[osl-drupal::default]
+  - name: drush
+    run_list:
+      - recipe[yum::epel]
+      - recipe[osl-drupal::drush]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,14 +1,5 @@
 ---
-provisioner:
-  name: chef_solo
-
 suites:
   - name: default
     run_list:
       - recipe[osl-drupal::default]
-    attributes:
-  - name: drush
-    run_list:
-      - recipe[yum::epel]
-      - recipe[osl-drupal::drush]
-    attributes:

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation --color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,21 @@
+AllCops:
+  Include:
+    - '**/Berksfile'
+    - '**/Cheffile'
+  Exclude:
+    - 'metadata.rb'
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+
+Metrics/LineLength:
+  Max: 120
+
+Style/IfUnlessModifier:
+  MaxLineLength: 120
+
+Style/WhileUntilModifier:
+  MaxLineLength: 120
+
+Metrics/BlockLength:
+  Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,5 @@
-cookbook "php", "<= 1.2.4"
-cookbook "yum", "< 3.0.0"
+cookbook 'php', '<= 1.2.4'
+cookbook 'yum', '< 3.0.0'
 
-site :opscode
-
+source   'https://supermarket.chef.io'
 metadata

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,5 @@
 cookbook 'php', '<= 1.2.4'
-cookbook 'yum', '< 3.0.0'
+cookbook 'yum'
 
 source   'https://supermarket.chef.io'
 metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+osl-drupal CHANGELOG
+====================
+This file is used to list changes made in each version of the
+osl-drupal cookbook.
+
+0.1.0
+-----
+- Initial release of osl-drupal
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,130 @@
+# Rake tasks
+
+require 'rake'
+
+require 'fileutils'
+require 'base64'
+require 'chef/encrypted_data_bag_item'
+require 'json'
+require 'openssl'
+
+snakeoil_file_path = 'test/integration/data_bags/certificates/snakeoil.json'
+encrypted_data_bag_secret_path = 'test/integration/encrypted_data_bag_secret'
+
+##
+# Run command wrapper
+def run_command(command)
+  if File.exist?('Gemfile.lock')
+    sh %(bundle exec #{command})
+  else
+    sh %(chef exec #{command})
+  end
+end
+
+##
+# Create a self-signed SSL certificate
+#
+def gen_ssl_cert
+  name = OpenSSL::X509::Name.new [
+    ['C', 'US'],
+    ['ST', 'Oregon'],
+    ['CN', 'OSU Open Source Lab'],
+    ['DC', 'example']
+  ]
+  key = OpenSSL::PKey::RSA.new 2048
+
+  cert = OpenSSL::X509::Certificate.new
+  cert.version = 2
+  cert.serial = 2
+  cert.subject = name
+  cert.public_key = key.public_key
+  cert.not_before = Time.now
+  cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60 # 1 years validity
+
+  # Self-sign the Certificate
+  cert.issuer = name
+  cert.sign(key, OpenSSL::Digest::SHA1.new)
+
+  return cert, key
+end
+
+##
+# Create a data bag item (with the id of snakeoil) containing a self-signed SSL
+#  certificate
+#
+def ssl_data_bag_item
+  cert, key = gen_ssl_cert
+  Chef::DataBagItem.from_hash(
+    'id' => 'snakeoil',
+    'cert' => cert.to_pem,
+    'key' => key.to_pem
+  )
+end
+
+##
+# Create the integration tests directory if it doesn't exist
+#
+directory 'test/integration'
+
+##
+# Generates a 512 byte random sequence and write it to
+#  'test/integration/encrypted_data_bag_secret'
+#
+file encrypted_data_bag_secret_path => 'test/integration' do
+  encrypted_data_bag_secret = OpenSSL::Random.random_bytes(512)
+  open encrypted_data_bag_secret_path, 'w' do |io|
+    io.write Base64.encode64(encrypted_data_bag_secret)
+  end
+end
+
+##
+# Create the certificates data bag if it doesn't exist
+#
+directory 'test/integration/data_bags/certificates' => 'test/integration'
+
+##
+# Create the encrypted snakeoil certificate under
+#  test/integration/data_bags/certificates
+#
+file snakeoil_file_path => [
+  'test/integration/data_bags/certificates',
+  'test/integration/encrypted_data_bag_secret'
+] do
+
+  encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
+    encrypted_data_bag_secret_path
+  )
+
+  encrypted_snakeoil_cert = Chef::EncryptedDataBagItem.encrypt_data_bag_item(
+    ssl_data_bag_item, encrypted_data_bag_secret
+  )
+
+  open snakeoil_file_path, 'w' do |io|
+    io.write JSON.pretty_generate(encrypted_snakeoil_cert)
+  end
+end
+
+desc 'Create an Encrypted Databag Snakeoil SSL Certificate'
+task snakeoil: snakeoil_file_path
+
+desc 'Create an Encrypted Databag Secret'
+task secret_file: encrypted_data_bag_secret_path
+
+require 'rubocop/rake_task'
+desc 'Run RuboCop (style) tests'
+RuboCop::RakeTask.new(:style)
+
+desc 'Run FoodCritic (lint) tests'
+task :lint do
+    run_command('foodcritic --epic-fail any .')
+end
+
+desc 'Run RSpec (unit) tests'
+task :unit do
+    run_command('rspec')
+end
+
+desc 'Run all tests'
+task test: [:style, :lint, :unit]
+
+task default: :test

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
-default['osl-drupal']['drush']['repo-url'] = "http://pkg.tag1consulting.com/drush/drush-6/el6/noarch/"
+default['osl-drupal']['drush']['repo-url'] = 'http://pkg.tag1consulting.com/drush/drush-6/el6/noarch/'
 default['osl-drupal']['drush']['version'] = nil

--- a/chefignore
+++ b/chefignore
@@ -77,7 +77,6 @@ tmp
 # Cookbooks #
 #############
 CONTRIBUTING
-CHANGELOG*
 
 # Strainer #
 ############

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,10 +2,13 @@ name             'osl-drupal'
 maintainer       'Oregon State University'
 maintainer_email 'systems@osuosl.org'
 license          'Apache 2.0'
+issues_url       'https://github.com/osuosl-cookbooks/osl-drupal/issues'
+source_url       'https://github.com/osuosl-cookbooks/osl-drupal'
 description      'Installs/Configures osl-drupal'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.1'
 depends          'php'
 depends          'yum', '>= 3.0.0'
+depends          'yum-epel'
 
 supports         'centos', '~> 6.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,13 +3,13 @@
 # Recipe:: default
 #
 # Copyright (C) 2014 Oregon State University
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/recipes/drush.rb
+++ b/recipes/drush.rb
@@ -3,13 +3,13 @@
 # Recipe:: drush
 #
 # Copyright (C) 2014 Oregon State University
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,19 +17,17 @@
 # limitations under the License.
 #
 
-include_recipe "php"
-include_recipe "yum"
-include_recipe "yum-epel"
+include_recipe 'php'
+include_recipe 'yum'
+include_recipe 'yum-epel'
 
-yum_repository "drush" do
-    name "drush"
-    url node['osl-drupal']['drush']['repo-url']
-    action :create
+yum_repository 'drush' do
+  name 'drush'
+  url node['osl-drupal']['drush']['repo-url']
+  action :create
 end
 
-package "drush" do
-    if node['osl-drupal']['drush']['version'] then
-    version node['osl-drupal']['drush']['version']
-    end
-    action :install
+package 'drush' do
+  version node['osl-drupal']['drush']['version'] if node['osl-drupal']['drush']['version']
+  action :install
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,14 @@
+require_relative 'spec_helper'
+
+describe 'osl-drupal::default' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/drush_spec.rb
+++ b/spec/drush_spec.rb
@@ -1,0 +1,14 @@
+require_relative 'spec_helper'
+
+describe 'osl-drupal::drush' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,15 +13,9 @@ CENTOS_6 = {
   version: '6.7'
 }.freeze
 
-DEBIAN_8 = {
-  platform: 'debian',
-  version: '8.4'
-}.freeze
-
 ALL_PLATFORMS = [
   CENTOS_6,
-  CENTOS_7,
-  DEBIAN_8
+  CENTOS_7
 ].freeze
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,29 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+ChefSpec::Coverage.start! { add_filter 'osl-drupal' }
+
+CENTOS_7 = {
+  platform: 'centos',
+  version: '7.2.1511'
+}.freeze
+
+CENTOS_6 = {
+  platform: 'centos',
+  version: '6.7'
+}.freeze
+
+DEBIAN_8 = {
+  platform: 'debian',
+  version: '8.4'
+}.freeze
+
+ALL_PLATFORMS = [
+  CENTOS_6,
+  CENTOS_7,
+  DEBIAN_8
+].freeze
+
+RSpec.configure do |config|
+  config.log_level = :fatal
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
Chefspec tests need to be written for osl-drupal. In order to pass rake, it needs to pass rubocop and foodcritic before it even gets to chefspec. I also ran chef generate in order to add necessary files and changed deprecations.