### PR TITLE
Added chefspec tests do drush recipe

### DIFF
--- a/spec/drush_spec.rb
+++ b/spec/drush_spec.rb
@@ -9,6 +9,20 @@ describe 'osl-drupal::drush' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
+      it 'should include recipes' do
+        %w(php yum yum-epel).each do |r|
+          expect(chef_run).to include_recipe(r)
+        end
+      end
+      it do
+        expect(chef_run).to create_yum_repository('drush').with(
+          name: 'drush',
+          url: chef_run.node['osl-drupal']['drush']['repo-url']
+        )
+      end
+      it do
+        expect(chef_run).to install_package('drush').with(version: chef_run.node['osl-drupal']['drush']['version'])
+      end
     end
   end
 end


### PR DESCRIPTION
All recipes in our cookbooks need to have tests. After this PR the drush recipe will have ChefSpec tests, and that will finish ChefSpec test writing for this cookbook! 

Expected output:
```
cthalmann@blue:~/githubRepos/osl-drupal$ rake
Running RuboCop...
Inspecting 8 files
........

8 files inspected, no offenses detected
chef exec foodcritic --epic-fail any .

chef exec rspec

osl-drupal::default
  centos 6.7
    converges successfully
  centos 7.2.1511
    converges successfully

osl-drupal::drush
  centos 6.7
    converges successfully
    should include recipes
    should create yum_repository "drush"
    should install package "drush"
  centos 7.2.1511
    converges successfully
    should include recipes
    should create yum_repository "drush"
    should install package "drush"

Finished in 16 seconds (files took 2.39 seconds to load)
10 examples, 0 failures


ChefSpec Coverage report generated...

  Total Resources:   2
  Touched Resources: 2
  Touch Coverage:    100.0%

You are awesome and so is your test coverage! Have a fantastic day!
```
